### PR TITLE
Fix coding style via php-cs-fixer

### DIFF
--- a/src/AsyncClient.php
+++ b/src/AsyncClient.php
@@ -2,11 +2,11 @@
 
 namespace ApiClients\Client\Skeleton;
 
+use ApiClients\Client\Skeleton\CommandBus\Command\MethodCommand;
+use ApiClients\Client\Skeleton\CommandBus\Command\StreamCommand;
 use ApiClients\Foundation\ClientInterface;
 use ApiClients\Foundation\Factory;
 use ApiClients\Foundation\Resource\ResourceInterface;
-use ApiClients\Client\Skeleton\CommandBus\Command\MethodCommand;
-use ApiClients\Client\Skeleton\CommandBus\Command\StreamCommand;
 use React\EventLoop\LoopInterface;
 use React\Promise\CancellablePromiseInterface;
 use React\Promise\PromiseInterface;


### PR DESCRIPTION
# Changed log
- According to the PR #29, the coding style check is failed when the `php-7.0` version test
- Resolves the coding style check issue.