### PR TITLE
Allow php-nightly to be failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,18 @@ matrix:
       env:
         - dependencies=highest
         - dropPlatform=false
+  allow_failures:
+    - php: nightly
+      env:
+        - dropPlatform=false
+    - php: nightly
+      env:
+        - dependencies=lowest
+        - dropPlatform=false
+    - php: nightly
+      env:
+        - dependencies=highest
+        - dropPlatform=false
 
 ## Install or update dependencies
 install:


### PR DESCRIPTION
# Changed log
- Add `allow_failures` block to allow the `php-nightly` to be failed.
Nobody can guarantee that the `php-nightly` test always is successful.